### PR TITLE
Add /for-hire and promote it on home page

### DIFF
--- a/_data/for-hire/index.yml
+++ b/_data/for-hire/index.yml
@@ -1,0 +1,29 @@
+title: I solve technology problems.
+_links:
+  oss:
+    title: Open Source
+    href: https://github.com/gregoryjscott?tab=repositories
+
+  resume:
+    title: Resume
+    href: /resume/
+
+  projects:
+    title: Projects
+    href: /projects
+
+  languages:
+    title: Languages
+    href: /languages/
+
+  os:
+    title: Operating Systems
+    href: /os/
+
+  db:
+    title: Databases
+    href: /db/
+
+  email:
+    title: Email me.
+    href: mailto:me@gregoryjscott.com

--- a/_data/index.yml
+++ b/_data/index.yml
@@ -1,29 +1,10 @@
 title: Hi, I'm Greg. I use software to make the world a better place.
 desc: The website of Gregory J. Scott.
 _links:
-  work:
-    - title: Projects
-      href: /projects/
+  recommend:
+    title: How can I help you?
+    href: /for-hire/
 
-    - title: Resume
-      href: /resume/
-
-    - title: GitHub
-      href: https://github.com/gregoryjscott
-
-  skills:
-    - title: Languages
-      href: /languages/
-
-    - title: Operating Systems
-      href: /os/
-
-    - title: Databases
-      href: /db/
-
-  contact:
-    - title: Email
-      href: mailto:me@gregoryjscott.com
-
-    - title: Twitter
-      href: https://twitter.com/gregoryjscott
+  email:
+    title: Email me.
+    href: mailto:me@gregoryjscott.com

--- a/db/index.md
+++ b/db/index.md
@@ -19,6 +19,6 @@ My projects use these databases.
 {% for item in page.items %}
   <h1>{{ item.title }}</h1>
 
-  {% include links-ul.md data=item %}
+  {% include links-ul.html data=item %}
 {% endfor %}
 </section>

--- a/for-hire/index.md
+++ b/for-hire/index.md
@@ -1,0 +1,64 @@
+---
+layout: default
+---
+
+<header>
+<nav>
+<a href="/">gregoryjscott</a> / for-hire
+</nav>
+
+<h1>{{ page.title }}</h1>
+</header>
+
+<article markdown="1">
+Technology moves so fast. Change is exciting, but it's also a little scary. We can't stop it, so our only choice is to embrace it. Fortunately, it turns out that change isn't so scary if you prepare for it. In fact, it can even be fun!
+
+**I've helped schools, governments, and businesses** of all kinds build systems that work _and_ change over time. Technology systems are either improving or dying - that's how technology evolves.
+
+In this world filled with technology, chances are good that you're dealing with technology problems at your place of work. Perhaps **I can help you**.
+</article>
+
+## Check out my work.
+
+<article markdown="1">
+My career has been filled with challenging projects, engaged clients, great companies, and awesome teammates. I've been very fortunate. Feel free to browse through my projects or look over my resume.
+</article>
+
+<a class="button" href="{{ page._links.projects.href }}">{{ page._links.projects.title }}</a>
+
+<a class="button" href="{{ page._links.resume.href }}">{{ page._links.resume.title }}</a>
+
+## Want technical details?
+
+<article markdown="1">
+I've got you covered. You can browse my work by skill such as language, database, or operating system. Everything is cross-referenced with hyperlinks so knock yourself out.
+</article>
+
+<a class="button" href="{{ page._links.languages.href }}">{{ page._links.languages.title }}</a>
+
+<a class="button" href="{{ page._links.db.href }}">{{ page._links.db.title }}</a>
+
+<a class="button" href="{{ page._links.os.href }}">{{ page._links.os.title }}</a>
+
+## Show me some code!
+
+<article markdown="1">
+You bet. You can view the source code for my open source projects on GitHub.
+</article>
+
+<a class="button" href="{{ page._links.oss.href }}">{{ page._links.oss.title }}</a>
+
+## Think I might be able to help you?
+
+<article markdown="1">
+Great! This is how it works.
+
+1. Send me a quick email to let me know you're interested.
+2. We'll start with a 1 - 2 hour meeting. You'll tell me about your technologies, problems, and ideas. I'll tell you how I can solve your problems and make your ideas become reality.
+2. If we choose to pursue a business relationship, then I'll send over a contract. The contract will define how the relationship will work, including everything that I'll need from you to get started.
+3. After the contract is signed we'll start making your technology troubles go away!
+
+I love to teach, learn, and build technology, and I'm pretty good at it. Please let me know if I can put these skills to use for you. Thank you for your consideration.
+</article>
+
+<a class="button recommend" href="{{ page._links.email.href }}">{{ page._links.email.title }}</a>

--- a/index.md
+++ b/index.md
@@ -5,9 +5,9 @@ layout: default
 <header>
   <nav>&nbsp;</nav>
 
-  <h1>Hi, <a href="/me">I'm Greg.</a> I'm a full-stack programmer for hire.</h1>
+  <h1>Hi, I'm Greg. I'm a full-stack programmer for hire.</h1>
 </header>
 
-<section markdown="1">
-{% include links-ul.md data=page %}
+<section>
+{% include links-ul.html data=page %}
 </section>

--- a/languages/index.md
+++ b/languages/index.md
@@ -19,6 +19,6 @@ My projects use these programming languages.
 {% for item in page.items %}
   <h1>{{ item.title }}</h1>
 
-  {% include links-ul.md data=item %}
+  {% include links-ul.html data=item %}
 {% endfor %}
 </section>

--- a/os/index.md
+++ b/os/index.md
@@ -19,6 +19,6 @@ My projects run on these operating systems.
 {% for item in page.items %}
   <h1>{{ item.title }}</h1>
 
-  {% include links-ul.md data=item %}
+  {% include links-ul.html data=item %}
 {% endfor %}
 </section>

--- a/projects/index.md
+++ b/projects/index.md
@@ -21,6 +21,6 @@ These are most of my current and past projects. Projects can also be explored by
 
   <p><em>{{ item.subtitle }}</em></p>
 
-  {% include links-ul.md data=item %}
+  {% include links-ul.html data=item %}
 {% endfor %}
 </section>


### PR DESCRIPTION
Summary
- Adds new /for-hire page
- Changes home page to direct visitors to /for-hire
- Uses latest roomy templates

TODO
- [x] Clean up commits
